### PR TITLE
Parse & build icon attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,16 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+### RubyMine+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+!.idea/jsLinters
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+### END RubyMine+all ###

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ bookmarks.each do |b|
   b.add_date        # DateTime
   b.last_visit      # DateTime
   b.last_modified   # DateTime
+  b.icon            # String
+  b.icon_uri        # String
 end
 ```
 
@@ -47,16 +49,13 @@ end
 builder = Markio::Builder.new
 builder.bookmarks << Markio::Bookmark.create({
   :title => "Google",
-  :href => "http://google.com"
+  :href => "http://google.com",
+  :icon => "data:image/png;base64,iVBORw==",
+  :icon_uri => "https://awesome.com/favicon.ico"
 })
 file_contents = builder.build_string
 File.open('/path/to/bookmarks.html', 'w') { |f| f.write file_contents }
 ```
-
-## TODO
-
-  - Builder output to file
-  - Builder should not ignore bookmark folders
 
 ## Contributing
 

--- a/lib/markio/bookmark.rb
+++ b/lib/markio/bookmark.rb
@@ -1,7 +1,7 @@
 require 'date'
 class Markio::Bookmark
 
-  attr_accessor :title, :href, :add_date, :last_visit, :last_modified, :folders
+  attr_accessor :title, :href, :add_date, :last_visit, :last_modified, :folders, :icon_uri, :icon
 
   def self.create data
     bookmark = new
@@ -11,6 +11,8 @@ class Markio::Bookmark
     bookmark.last_visit = data[:add_date]
     bookmark.last_modified = data[:last_modified]
     bookmark.folders = data[:folders] || []
+    bookmark.icon_uri = data[:icon_uri]
+    bookmark.icon = data[:icon]
     bookmark
   end
 

--- a/lib/markio/builder.rb
+++ b/lib/markio/builder.rb
@@ -74,6 +74,8 @@ END
       params[:add_date] = b.add_date.to_time.to_i if b.add_date
       params[:last_visit] = b.last_visit.to_time.to_i if b.last_visit
       params[:last_modified] = b.last_modified.to_time.to_i if b.last_modified
+      params[:icon_uri] = b.icon_uri if b.icon_uri
+      params[:icon] = b.icon if b.icon
       html.a(b.title, params)
     }
   end

--- a/lib/markio/parser.rb
+++ b/lib/markio/parser.rb
@@ -48,6 +48,8 @@ module Markio
       bookmark.add_date = parse_timestamp data['add_date']
       bookmark.last_visit = parse_timestamp data['last_visit']
       bookmark.last_modified = parse_timestamp data['last_modified']
+      bookmark.icon = data['icon']
+      bookmark.icon_uri = data['icon_uri']
       bookmark
     end
 

--- a/spec/assets/one_bookmark.html
+++ b/spec/assets/one_bookmark.html
@@ -6,5 +6,5 @@ Do Not Edit! -->
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks</H1>
 <DL><p>
-<DT><A HREF="https://saveit.in/" ADD_DATE="1350743281" LAST_VISIT="1350743282" LAST_MODIFIED="1350743283" PRIVATE="0" TAGS="Bookmarking">Save It - Simple, secure bookmarks</A>
+<DT><A HREF="https://saveit.in/" ADD_DATE="1350743281" ICON_URI="http://www.mozilla.org/2005/made-up-favicon/0-1350925942950" ICON="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" LAST_VISIT="1350743282" LAST_MODIFIED="1350743283" PRIVATE="0" TAGS="Bookmarking">Save It - Simple, secure bookmarks</A>
 </DL><p>

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -17,7 +17,9 @@ module Markio
         :href => "http://test.com",
         :add_date => Date.parse('2012-01-12 11:22:33').to_datetime,
         :last_visit => Date.parse('2012-01-13 10:20:30').to_datetime,
-        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime
+        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime,
+        :icon => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        :icon_uri => "http://www.mozilla.org/2005/made-up-favicon/0-1350925942950"
       })
       file_contents = builder.build_string
       file_contents.length.should_not be_nil
@@ -26,6 +28,8 @@ module Markio
       file_contents.should match "add_date"
       file_contents.should match "last_visit"
       file_contents.should match "last_modified"
+      file_contents.should match "icon"
+      file_contents.should match "icon_uri"
     end
 
 
@@ -40,7 +44,9 @@ module Markio
         :href => "http://test2.com",
         :add_date => Date.parse('2012-01-12 11:22:33').to_datetime,
         :last_visit => Date.parse('2012-01-13 10:20:30').to_datetime,
-        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime
+        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime,
+        :icon => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        :icon_uri => "http://www.mozilla.org/2005/made-up-favicon/0-1350925942950"
       })
       file_contents = builder.build_string
       bookmarks = Markio.parse file_contents
@@ -61,7 +67,9 @@ module Markio
         :href => "http://test2.com",
         :add_date => Date.parse('2012-01-12 11:22:33').to_datetime,
         :last_visit => Date.parse('2012-01-13 10:20:30').to_datetime,
-        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime
+        :last_modified => Date.parse('2012-01-14 10:21:31').to_datetime,
+        :icon => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        :icon_uri => "http://www.mozilla.org/2005/made-up-favicon/0-1350925942950"
       })
       file_contents = builder.build_string
       bookmarks = Markio.parse file_contents

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -19,6 +19,9 @@ module Markio
       bookmark.add_date.class.should be DateTime
       bookmark.last_visit.class.should be DateTime
       bookmark.last_modified.class.should be DateTime
+      bookmark.icon.should eq "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQD"\
+        "wAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+      bookmark.icon_uri.should eq "http://www.mozilla.org/2005/made-up-favicon/0-1350925942950"
     end
 
     it 'should parse multiple bookmarks' do
@@ -53,6 +56,5 @@ module Markio
       bookmarks = Markio.parse File.open "spec/assets/corrupted.html"
       bookmarks.should eq []
     end
-
   end
 end


### PR DESCRIPTION
Parse the attributes `ICON` & `ICON_URI` which are distinct attribute names to include the favicon in files generated by major browsers.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Tests are added or updated if you fix a bug or add a feature